### PR TITLE
Add reusable workflow to check cargo install

### DIFF
--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -7,6 +7,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   install:
     name: Rust ${{matrix.rust}}

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -1,0 +1,22 @@
+name: check_install
+
+on:
+  workflow_call:
+    inputs:
+      crate:
+        required: true
+        type: string
+
+jobs:
+  install:
+    name: Rust ${{matrix.rust}}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [stable, nightly]
+    steps:
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{matrix.rust}}
+      - run: cargo install ${{inputs.crate}}

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -22,4 +22,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
-      - run: cargo install ${{inputs.crate}} ${{matrix.locked && '--locked' || ''}}
+      - name: cargo install ${{inputs.crate}} ${{matrix.locked && '--locked' || ''}}
+        run: cargo install ${{inputs.crate}} ${{matrix.locked && '--locked' || ''}} 2>&1 | tee ${{runner.temp}}/check_install.log
+      - if: matrix.locked
+        name: Check for yanked dependency
+        run: |
+          ! grep --quiet 'package `[^`]\+` in Cargo\.lock is yanked' ${{runner.temp}}/check_install.log

--- a/.github/workflows/check_install.yml
+++ b/.github/workflows/check_install.yml
@@ -11,14 +11,15 @@ permissions: {}
 
 jobs:
   install:
-    name: Rust ${{matrix.rust}}
+    name: Rust ${{matrix.rust}}${{matrix.locked && ', locked' || ''}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         rust: [stable, nightly]
+        locked: [false, true]
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
-      - run: cargo install ${{inputs.crate}}
+      - run: cargo install ${{inputs.crate}} ${{matrix.locked && '--locked' || ''}}


### PR DESCRIPTION
Example usage:

```yaml
on:
  workflow_dispatch:
  schedule: [cron: "40 1 * * *"]

permissions: {}

env:
  RUSTFLAGS: -Dwarnings

jobs:
  install:
    name: Install
    uses: dtolnay/.github/.github/workflows/check_install.yml@master
    with:
      crate: faketty
```