### PR TITLE
Add reusable workflow for publishing release sources as tgz artifact

### DIFF
--- a/.github/workflows/release_tgz.yml
+++ b/.github/workflows/release_tgz.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on: workflow_call
+
+permissions:
+  contents: write
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine version from tag name
+        id: vars
+        run: echo version="${tag_name#v}" >> $GITHUB_OUTPUT
+        env:
+          tag_name: ${{github.event.release.tag_name}}
+      - name: Package sources into tar.gz
+        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{steps.vars.outputs.version}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
+      - name: Upload release archive
+        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
+        env:
+          GH_TOKEN: ${{github.token}}


### PR DESCRIPTION
Copied from https://github.com/dtolnay/cxx/blob/6c117a8475c64ae6ce24255acfe06fb6289f4d56/.github/workflows/release.yml with the `on:` trigger modified to `workflow_call`.

Usable as:

```yaml
name: Release

on:
  release:
    types: [released]

permissions:
  contents: write

jobs:
  upload:
    uses: dtolnay/.github/.github/workflows/release_tgz.yml@master
```